### PR TITLE
Added new field to the users schema to identify the type of the login

### DIFF
--- a/src/schemas/tables/users.sql
+++ b/src/schemas/tables/users.sql
@@ -1,4 +1,5 @@
 CREATE TYPE gender_opt AS ENUM ('M', 'F', 'O');
+CREATE TYPE login_type_opt AS ENUM ('EMAIL_PASSWORD', 'GOOGLE');
 
 CREATE TABLE users (
     id TEXT PRIMARY KEY DEFAULT UPPER(REPLACE(uuid_generate_v4()::TEXT, '-', '')),
@@ -15,6 +16,7 @@ CREATE TABLE users (
     is_verified BOOLEAN DEFAULT FALSE,
     last_login TIMESTAMP,
     login_count INT DEFAULT 0,
+    login_type login_type_opt,
     created_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     created_by VARCHAR(100) DEFAULT 'SYSTEM',
     modified_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
Added a new field login_type to the users schema. This field will help in identifying the type of the login, if the user login is direct email type or google login.